### PR TITLE
Updated to use ctrulib at 42ce1d8

### DIFF
--- a/3DS/cxi/build_cia.rsf
+++ b/3DS/cxi/build_cia.rsf
@@ -5,7 +5,7 @@ BasicInfo:
   ContentType             : Application # Application / SystemUpdate / Manual / Child / Trial
   Logo                    : Nintendo # Nintendo / Licensed / Distributed / iQue / iQueForSystem
 
-Rom:
+RomFs:
   # Specifies the root path of the file system to include in the ROM.
   # HostRoot                : "$(ROMFS_ROOT)"
 
@@ -26,21 +26,6 @@ Option:
   FreeProductCode         : true # Removes limitations on ProductCode
   EnableCrypt             : false # Enables encryption for NCCH and CIA
   MediaFootPadding        : false # If true CCI files are created with padding
-
-ExeFs: # these are the program segments from the ELF, check your elf for the appropriate segment names
-  ReadOnly: 
-   - .rodata
-   - RO
-  ReadWrite: 
-   - .data
-   - RO
-  Text: 
-   - .init
-   - .text
-   - STUP_ENTRY
-   
-PlainRegion: # only used with SDK ELFs 
- # - .module_id
   
 AccessControlInfo:
   # UseOtherVariationSaveData : true

--- a/3DS/cxi/gw_workaround.rsf
+++ b/3DS/cxi/gw_workaround.rsf
@@ -5,7 +5,7 @@ BasicInfo:
   ContentType             : Application
   Logo                    : Nintendo # Nintendo / Licensed / Distributed / iQue / iQueForSystem
 
-Rom:
+RomFs:
   # Specifies the root path of the file system to include in the ROM.
   #HostRoot                : "romfs"
 
@@ -25,21 +25,6 @@ Option:
   MediaFootPadding        : false # If true CCI files are created with padding
   EnableCrypt             : true # Enables encryption for NCCH and CIA
   EnableCompress          : true # Compresses exefs code
-
-ExeFs: # these are the program segments from the ELF, check your elf for the appropriate segment names
-  ReadOnly: 
-   - .rodata
-   - RO
-  ReadWrite: 
-   - .data
-   - RO
-  Text: 
-   - .init
-   - .text
-   - STUP_ENTRY
-   
-PlainRegion: # only used with SDK ELFs 
- - .module_id
   
 AccessControlInfo:
   #UseExtSaveData : true

--- a/3DS/include/drawing.h
+++ b/3DS/include/drawing.h
@@ -8,13 +8,13 @@
 #define REG_LCDBACKLIGHTSUB (u32)(0x1ED02A40 - 0x1EB00000)
 #endif
 
-inline void clearScreen(void);
+extern inline void clearScreen(void);
 
 #define drawPixelRGB(x, y, r, g, b) drawPixelRGBFramebuffer(0, x, y, r, g, b)
 void drawPixelRGBFramebuffer(u8 *fb, int x, int y, u8 r, u8 g, u8 b);
 
 #define drawBox(x, y, width, height, r, g, b) drawBoxFramebuffer(0, x, y, width, height, r, g, b)
-inline void drawBoxFramebuffer(u8 *fb, int x, int y, int width, int height, u8 r, u8 g, u8 b);
+extern inline void drawBoxFramebuffer(u8 *fb, int x, int y, int width, int height, u8 r, u8 g, u8 b);
 
 #define drawString(sx, sy, text, ...) drawStringFramebuffer(0, sx, sy, text, ##__VA_ARGS__)
 void drawStringFramebuffer(u8 *fb, int sx, int sy, char *text, ...);

--- a/3DS/include/keyboard.h
+++ b/3DS/include/keyboard.h
@@ -8,4 +8,4 @@ extern unsigned char keyboardToggle;
 extern unsigned char keyboardGfx[320 * 240 * 3];
 
 void preRenderKeyboard(void);
-inline void drawKeyboard(void);
+extern void drawKeyboard(void);

--- a/3DS/source/drawing.c
+++ b/3DS/source/drawing.c
@@ -162,14 +162,14 @@ static u32 brightnessSub;
 void disableBacklight() {
 	u32 off = 0;
 	
-	GSPGPU_ReadHWRegs(NULL, REG_LCDBACKLIGHTMAIN, &brightnessMain, 4);
-	GSPGPU_ReadHWRegs(NULL, REG_LCDBACKLIGHTSUB, &brightnessSub, 4);
+	GSPGPU_ReadHWRegs(REG_LCDBACKLIGHTMAIN, &brightnessMain, 4);
+	GSPGPU_ReadHWRegs(REG_LCDBACKLIGHTSUB, &brightnessSub, 4);
 	
-	GSPGPU_WriteHWRegs(NULL, REG_LCDBACKLIGHTMAIN, &off, 4);
-	GSPGPU_WriteHWRegs(NULL, REG_LCDBACKLIGHTSUB, &off, 4);
+	GSPGPU_WriteHWRegs(REG_LCDBACKLIGHTMAIN, &off, 4);
+	GSPGPU_WriteHWRegs(REG_LCDBACKLIGHTSUB, &off, 4);
 }
 
 void enableBacklight() {
-	GSPGPU_WriteHWRegs(NULL, REG_LCDBACKLIGHTMAIN, &brightnessMain, 4);
-	GSPGPU_WriteHWRegs(NULL, REG_LCDBACKLIGHTSUB, &brightnessSub, 4);
+	GSPGPU_WriteHWRegs(REG_LCDBACKLIGHTMAIN, &brightnessMain, 4);
+	GSPGPU_WriteHWRegs(REG_LCDBACKLIGHTSUB, &brightnessSub, 4);
 }

--- a/3DS/source/main.c
+++ b/3DS/source/main.c
@@ -53,10 +53,10 @@ int main(void) {
 	gfxFlushBuffers();
 	gfxSwapBuffers();
 	
-	SOC_Initialize((u32 *)memalign(0x1000, 0x100000), 0x100000);
+	socInit((u32 *)memalign(0x1000, 0x100000), 0x100000);
 	
 	u32 wifiStatus = 0;
-	ACU_GetWifiStatus(NULL, &wifiStatus);
+	ACU_GetWifiStatus(&wifiStatus);
 	if(!wifiStatus) {
 		hang("No WiFi! Is your wireless slider on?");
 	}
@@ -150,7 +150,7 @@ int main(void) {
 	
 	enableBacklight();
 	
-	SOC_Shutdown();
+	SOCU_ShutdownSockets();
 	
 	svcCloseHandle(fileHandle);
 	fsExit();

--- a/3DS/source/settings.c
+++ b/3DS/source/settings.c
@@ -40,10 +40,10 @@ bool readSettings(void) {
 	u64 size;
 	u32 bytesRead;
 	
-	FS_archive sdmcArchive = (FS_archive){ARCH_SDMC, (FS_path){PATH_EMPTY, 1, (u8*)""}};
-	FS_path filePath = FS_makePath(PATH_CHAR, "/3DSController.ini");
+	FS_Archive sdmcArchive = (FS_Archive){ARCHIVE_SDMC, (FS_Path){PATH_EMPTY, 1, (u8*)""}};
+	FS_Path filePath = fsMakePath(PATH_ASCII, "/3DSController.ini");
 	
-	Result ret = FSUSER_OpenFileDirectly(NULL, &fileHandle, sdmcArchive, filePath, FS_OPEN_READ, FS_ATTRIBUTE_NONE);
+	Result ret = FSUSER_OpenFileDirectly(&fileHandle, sdmcArchive, filePath, FS_OPEN_READ, 0x00000000);
 	if(ret) return false;
 	
 	ret = FSFILE_GetSize(fileHandle, &size);


### PR DESCRIPTION
With the newest (as of this writing) ctrulib, 3DSController's 3DS portion would not compile.

I've gone through and updated everything and now it compiles without a fuss. `makerom` threw a fit about the .RSFs using undefined keys, so I edited those accordingly as well.

In `3DS\source\settings.c`, I could not find a counterpart to `FS_ATTRIBUTE_NONE` in the latest ctrulib, so I put `0x00000000` in its place as that's what it used to be defined as. It is not the best solution, but it is only used in the one spot anyhow.

I've tested both the .3DSX and .CIA files using my changes on my own O3DS XL running an rxTools EmuNAND at 10.5(u) and everything appears to be in working order.