### PR TITLE
Enable ir:rst in RSF for N3DS buttons

### DIFF
--- a/3DS/cxi/build_cia.rsf
+++ b/3DS/cxi/build_cia.rsf
@@ -181,6 +181,8 @@ AccessControlInfo:
    - y2r:u
    - ldr:ro
    - ir:USER
+   - ir:u
+   - ir:rst
   
    
 SystemControlInfo:


### PR DESCRIPTION
Modify the RSF file for the CIA to allow the application to access ir:rst (and ir:u just for good measure), enabling support for New 3DS-specific buttons.